### PR TITLE
ボタンモーダルにプロコンの画像を表示して、視覚的にボタンを選択できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-bootstrap": "^2.4.0",
     "react-dom": "^18.2.0",
     "react-github-fork-ribbon": "^0.7.1",
+    "react-nintendo-switch-procon-renderer": "/Users/koji/src/react-nintendo-switch-procon-renderer",
     "react-router-dom": "^6.3.0"
   }
 }

--- a/src/components/buttons_modal.tsx
+++ b/src/components/buttons_modal.tsx
@@ -3,6 +3,7 @@
 import { jsx, css } from "@emotion/react";
 import React, { useState } from "react";
 import { Button, buttons } from "../types/button";
+import { Procon } from "react-nintendo-switch-procon-renderer";
 import Form from "react-bootstrap/Form";
 import { Button as BootstrapButton } from "react-bootstrap";
 
@@ -99,6 +100,7 @@ export const ButtonsModal = ({
                 />
               </div>
             ))}
+            <Procon pressedButtons={["zr", "up"]} />
           </div>
         </div>
         <hr />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5623,6 +5623,9 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-nintendo-switch-procon-renderer@/Users/koji/src/react-nintendo-switch-procon-renderer:
+  version "1.0.3"
+
 react-router-dom@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"


### PR DESCRIPTION
NOTE

* `yarn add /Users/koji/src/react-nintendo-switch-procon-renderer` 